### PR TITLE
fix: do not break with pending invitations + increase timeout

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -17,7 +17,7 @@ type HoneybadgerClient struct {
 
 func NewClient(host *string, apiToken *string) *HoneybadgerClient {
 	hbc := &HoneybadgerClient{
-		HTTPClient: &http.Client{Timeout: 10 * time.Second},
+		HTTPClient: &http.Client{Timeout: 30 * time.Second},
 		HostURL:    HoneybadgerURL,
 		ApiToken:   *apiToken,
 	}

--- a/cli/models.go
+++ b/cli/models.go
@@ -26,12 +26,13 @@ type HoneybadgerTeams struct {
 }
 
 type HoneybadgerTeam struct {
-	ID        int                  `json:"id"`
-	Name      string               `json:"name"`
-	CreatedAt string               `json:"created_at"`
-	Users     []HoneybadgerUser    `json:"members"`
-	Projects  []HoneybadgerProject `json:"projects"`
-	Owner     HoneybadgerTeamOwner `json:"owner"`
+	ID          int                     `json:"id"`
+	Name        string                  `json:"name"`
+	CreatedAt   string                  `json:"created_at"`
+	Users       []HoneybadgerUser       `json:"members"`
+	Projects    []HoneybadgerProject    `json:"projects"`
+	Invitations []HoneybadgerInvitation `json:"invitations"`
+	Owner       HoneybadgerTeamOwner    `json:"owner"`
 }
 
 type HoneybadgerProject struct {
@@ -41,6 +42,15 @@ type HoneybadgerProject struct {
 	DisablePublicLinks bool     `json:"disable_public_links"`
 	Token              string   `json:"token"`
 	Environments       []string `json:"environments"`
+}
+
+type HoneybadgerInvitation struct {
+	ID         int    `json:"id"`
+	Token      string `json:"token"`
+	Email      string `json:"email"`
+	IsAdmin    bool   `json:"admin"`
+	AcceptedAt string `json:"accepted_at"`
+	CreatedAt  string `json:"created_at"`
 }
 
 type HoneybadgerTeamOwner struct {

--- a/cli/users.go
+++ b/cli/users.go
@@ -106,7 +106,7 @@ func (hbc *HoneybadgerClient) DeleteUser(userID int, teamID int) error {
 
 // GetUserFromTeams - Get Users information from Teams
 func (hbc *HoneybadgerClient) GetUserFromTeams(userEmail string) (userTeams []HoneybadgerUser, err error) {
-	insertedUser := make(map[string]bool)
+	var insertedUser bool
 
 	teams, err := hbc.GetTeams()
 	if err != nil {
@@ -114,17 +114,17 @@ func (hbc *HoneybadgerClient) GetUserFromTeams(userEmail string) (userTeams []Ho
 	}
 
 	for _, team := range teams {
-		delete(insertedUser, userEmail) // Ensure that It is only valid fro the current team
+		insertedUser = false
 		for _, user := range team.Users {
 			if user.Email == userEmail {
 				user.TeamID = team.ID
 				userTeams = append(userTeams, user)
-				insertedUser[userEmail] = true
+				insertedUser = true
 			}
 		}
 
 		// Check if the user has a pending invitation. However, the user iss not already in member list
-		if _, ok := insertedUser[userEmail]; !ok {
+		if !insertedUser {
 			for _, userInvitation := range team.Invitations {
 				if userInvitation.Email == userEmail {
 					userTeams = append(

--- a/cli/users.go
+++ b/cli/users.go
@@ -115,34 +115,30 @@ func (hbc *HoneybadgerClient) GetUserFromTeams(userEmail string) (userTeams []Ho
 
 	for _, team := range teams {
 		for _, user := range team.Users {
-			if user.Email != userEmail {
-				continue
+			if user.Email == userEmail {
+				user.TeamID = team.ID
+				userTeams = append(userTeams, user)
+				insertedUser[userEmail] = true
 			}
-			user.TeamID = team.ID
-			userTeams = append(userTeams, user)
-			insertedUser[userEmail] = true
 		}
 
 		// Check if the user is invited but its not already in member list
 		if _, ok := insertedUser[userEmail]; !ok {
 			for _, userInvitation := range team.Invitations {
-				if userInvitation.Email != userEmail {
-					continue
+				if userInvitation.Email == userEmail {
+					userTeams = append(
+						userTeams,
+						HoneybadgerUser{
+							ID:        userInvitation.ID,
+							Email:     userInvitation.Email,
+							IsAdmin:   userInvitation.IsAdmin,
+							TeamID:    team.ID,
+							CreatedAt: userInvitation.CreatedAt,
+						},
+					)
 				}
-				userTeams = append(
-					userTeams,
-					HoneybadgerUser{
-						ID:        userInvitation.ID,
-						Email:     userInvitation.Email,
-						IsAdmin:   userInvitation.IsAdmin,
-						TeamID:    team.ID,
-						CreatedAt: userInvitation.CreatedAt,
-					},
-				)
-
 			}
 		}
-
 	}
 
 	return userTeams, nil

--- a/cli/users.go
+++ b/cli/users.go
@@ -104,7 +104,7 @@ func (hbc *HoneybadgerClient) DeleteUser(userID int, teamID int) error {
 	return nil
 }
 
-// GetUserFromTeams - Get User information from Teams
+// GetUserFromTeams - Get Users information from Teams
 func (hbc *HoneybadgerClient) GetUserFromTeams(userEmail string) (userTeams []HoneybadgerUser, err error) {
 	insertedUser := make(map[string]bool)
 
@@ -114,6 +114,7 @@ func (hbc *HoneybadgerClient) GetUserFromTeams(userEmail string) (userTeams []Ho
 	}
 
 	for _, team := range teams {
+		delete(insertedUser, userEmail)
 		for _, user := range team.Users {
 			if user.Email == userEmail {
 				user.TeamID = team.ID
@@ -144,7 +145,7 @@ func (hbc *HoneybadgerClient) GetUserFromTeams(userEmail string) (userTeams []Ho
 	return userTeams, nil
 }
 
-// GetUserFromTeams - Get User information from Teams
+// GetUserForTeam - Get User information from specific Team
 func (hbc *HoneybadgerClient) GetUserForTeam(userEmail string, teamID int) (HoneybadgerUser, error) {
 	userTeams, err := hbc.GetUserFromTeams(userEmail)
 	if err != nil {

--- a/cli/users.go
+++ b/cli/users.go
@@ -114,7 +114,7 @@ func (hbc *HoneybadgerClient) GetUserFromTeams(userEmail string) (userTeams []Ho
 	}
 
 	for _, team := range teams {
-		delete(insertedUser, userEmail)
+		delete(insertedUser, userEmail) // Ensure that It is only valid fro the current team
 		for _, user := range team.Users {
 			if user.Email == userEmail {
 				user.TeamID = team.ID
@@ -123,7 +123,7 @@ func (hbc *HoneybadgerClient) GetUserFromTeams(userEmail string) (userTeams []Ho
 			}
 		}
 
-		// Check if the user is invited but its not already in member list
+		// Check if the user has a pending invitation. However, the user iss not already in member list
 		if _, ok := insertedUser[userEmail]; !ok {
 			for _, userInvitation := range team.Invitations {
 				if userInvitation.Email == userEmail {


### PR DESCRIPTION
* increase timeout to 30 seconds. I got `│ Error: Get "https://app.honeybadger.io/v2/teams": context deadline exceeded (Client.Timeout exceeded while awaiting headers)`
* Do not try to re-add a user when it has a pending invitation. Honeybadger team added `invitations` into `/v2/teams` API endpoint to prevent extra calls to the API in order to know if a user it's a member or it has a pending invitation.